### PR TITLE
Documentation Improvements, Developer Site, and API Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# Dexter
-Smartwatch OS
+# UDXS Dexter
+## Open-source Smartwatch Operating System
+
+## Current State
+We are currently in the process of designing a set of APIs for building watchfaces (and eventually watch apps). We are getting closer to having a simulator just for watch-only watchfaces, with more stuff coming along later.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/docs/api/host.md
+++ b/docs/api/host.md
@@ -1,0 +1,2 @@
+# dexter.host
+### UDXS Dexter API Reference

--- a/docs/api/hw.md
+++ b/docs/api/hw.md
@@ -1,0 +1,26 @@
+# dexter.hw
+### UDXS Dexter API Reference
+
+## Introduction
+
+Dexter enables you to access hardware data through a simple API.
+
+
+**Note:** Currently, Dexter has no permissions system for applications. This may change in the future and it may mean apps need to be updated to properly request permissions before being able to use certain hardware features.
+
+## Reference
+
+- [dexter.hw](#dexterhw)
+    - [capabilities]()
+        - [hasHeartRate]()
+        - [hasAccel]()
+        - [hasCompass]()
+        - [hasGyro]()
+        - [hasVibration]()
+        - [hasColor]()
+    - [vibrate(ms)]()
+    - [vibrate(pattern)]()
+    - [stopVibrate()]()
+
+
+**Note:** This API is incomplete

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,4 @@
-# UDXS Dexter
-## API Reference
+# API Reference
 
 ### **Note:** All of this is a work-in-progress. APIs are not finalized.
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,12 +1,12 @@
 # UDXS Dexter
 ## API Reference
 
-**Note:** All of this is a work-in-progress. APIs are not finalized.
+### **Note:** All of this is a work-in-progress. APIs are not finalized.
 
 ## Watch APIs (Onboard)
 
-- ### User Interface & Rendering - [dexter.ui](ui.md)
-- ### Time - [dexter.time](time.md)
+- ### ~~User Interface & Rendering - [dexter.ui](ui.md)~~
+- ### ~~Time - [dexter.time](time.md)~~
 - ### ~~Now - [dexter.now](now.md)~~
 - ### ~~Communication - [dexter.host](host.md)~~
 - ### ~~Notifications - [dexter.notify](notify.md)~~

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,19 @@
+# UDXS Dexter
+## API Reference
+
+**Note:** All of this is a work-in-progress. APIs are not finalized.
+
+## Watch APIs (Onboard)
+
+- ### User Interface & Rendering - [dexter.ui](ui.md)
+- ### Time - [dexter.time](time.md)
+- ### ~~Now - [dexter.now](now.md)~~
+- ### ~~Communication - [dexter.host](host.md)~~
+- ### ~~Notifications - [dexter.notify](notify.md)~~
+- ### ~~Preferences - [dexter.prefs](prefs.md)~~
+- ### ~~Hardware Access - [dexter.hw](hw.md)~~
+
+**Note:** crossed-out APIs  are not complete yet.
+## Phone APIs (Companion)
+
+### To Be Determined

--- a/docs/api/notify.md
+++ b/docs/api/notify.md
@@ -1,0 +1,2 @@
+# dexter.notify
+### UDXS Dexter API Reference

--- a/docs/api/now.md
+++ b/docs/api/now.md
@@ -1,0 +1,2 @@
+# dexter.now
+### UDXS Dexter API Reference

--- a/docs/api/prefs.md
+++ b/docs/api/prefs.md
@@ -1,0 +1,2 @@
+# dexter.prefs
+### UDXS Dexter API Reference

--- a/docs/api/time.md
+++ b/docs/api/time.md
@@ -1,0 +1,2 @@
+# dexter.time
+### UDXS Dexter API Reference

--- a/docs/api/ui.md
+++ b/docs/api/ui.md
@@ -1,0 +1,2 @@
+# dexter.ui
+### UDXS Dexter API Reference

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -1,4 +1,4 @@
-# Dexter Basics
+# System Basics
 
 ## Lifecycle
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -4,4 +4,4 @@
 ## Watchfaces
 
 ### Intermediate
-- [Modern Map Watchface](examples/map/map.md)
+- [Modern Map Watchface](map/index.md)

--- a/docs/examples/map/index.md
+++ b/docs/examples/map/index.md
@@ -1,4 +1,5 @@
-# Dexter Modern Map Example
+# Modern Map Watchface
+## Intermediate Example
 
 **Note:** This example and its associated documentation is incomplete and has not been tested.
 

--- a/docs/examples/map/index.md
+++ b/docs/examples/map/index.md
@@ -2,9 +2,14 @@
 
 **Note:** This example and its associated documentation is incomplete and has not been tested.
 
+## Description
+This stylish watchface shows a simple road map behind the time. It is minimalistic and represent the sort of smart features we'd like to see in watchfaces.
+
+## About
+
 This watchface demonstrates Dexter's basic rendering and compositing capabilites as well as its ability to retrieve data from the host device (normally a phone). This example is well detailed and commented and takes advantage of some modern ES6 features.
 
-The watchface makes heavy use of `dexter.ui.vectorCanvas` and functions within `dexter.host`. It relies on `dexter.ui.absoluteLayout` to place elements with pixel positions and makes use of alignment features to center them.
+The watchface makes heavy use of `dexter.ui.vectorCanvas` and functions within `dexter.host`. It relies on `dexter.ui.absoluteLayout` to place elements with pixel positions and makes use of alignment features (`element.aligment`) to center them (`dexter.ui.center`).
 
 ## Images
 

--- a/docs/examples/map/map.js
+++ b/docs/examples/map/map.js
@@ -44,7 +44,7 @@ layout.add(mapVector) // We need to add the mapVector first so it's on the botto
 	shared system resources is available by
 	placing '@' before a path to a system resource.
 */
-let time = new dexter.ui.tlabel("@fonts/roboto", 48, dexter.ui.bold)
+let time = new dexter.ui.label("@fonts/roboto", 48, dexter.ui.bold)
 time.alignment = dexter.ui.center // Horizontally align the text to the center.
 time.color = new dexter.color(230, 230, 230) //  Set color to an off-white.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,20 @@
 # UDXS Dexter
-## Documentation
+## Developer Documentation
 
-## [Architecture Basics](basics.md)
 
-## [Watchface/Watchapp Examples](basics.md)
+## I am building Watchfaces and Watchapps for Dexter:
+### [API Reference](api/index.md)
+### [Watchface/Watchapp Examples](examples/index.md)
+
+### **Coming Soon:** Guides
+
+
+---
+## I am developing Dexter and related infrastructure:
+
+### [GitHub Repository](https://github.com/Codeocracy/Dexter)
+### [Architecture Basics](basics.md)
+
+---
+## I am porting Dexter to my watch:
+**Guides and information coming soon.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # UDXS Dexter
 ## Developer Documentation
 
-
+---
 ## I am building Watchfaces and Watchapps for Dexter:
 ### [API Reference](api/index.md)
 ### [Watchface/Watchapp Examples](examples/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
-# UDXS Dexter
-## Developer Documentation
+# Developer Documentation
 
 ---
 ## I am building Watchfaces and Watchapps for Dexter:


### PR DESCRIPTION
I've improved the documentation and have successfully made it into a full developer site. You can try my   fork's version of the developer site [here](https://udxs.me/Dexter) and, *when* this PR is merged, you will be able to access it [here](https://codeocracy.github.io/Dexter).

I've also started on a basic API structure but keep in mind it isn't complete. Take a look at the [dexter.hw](https://udxs.me/Dexter/api/hw.html) page to see what it may look like.